### PR TITLE
Add initial docker build and publish action

### DIFF
--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -3,7 +3,7 @@ name: build-and-publish-docker
 on:
   push:
     branches:
-      - "build_and_publish_docker"
+      - "master"
 
 jobs:
   docker:


### PR DESCRIPTION
This PR will adds Github Action to build the frontend image within Github and push it to DockerHub as a public image.

The workflow is only activated for now on the master branch and pushes the image to https://hub.docker.com/repository/docker/interlinkproject/frontend.

PS: @julenbadiola  I will activate only merge-commit rebase flow for the repositories to avoid merge commit overload in the history if you agree.